### PR TITLE
remove card img rules and height to display whole img

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -99,17 +99,10 @@ main::before {
 /* post container */
 .image-container {
     max-width: 100%;
-    max-height: 150px;
     overflow: hidden;
     display: flex;
     justify-content: center;
     align-items: center;
-}
-
-.image-container img {
-    width: auto;
-    height: 100%;
-    object-fit: cover;
 }
 
 .card {


### PR DESCRIPTION
Uploaded images were rendered too large for container. Whole images is visible now.